### PR TITLE
issue#3: Mutable fields should not be "public static"

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/app/AppletHarness.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/AppletHarness.java
@@ -53,7 +53,7 @@ import javax.swing.SwingUtilities;
  */
 public class AppletHarness extends Applet {
 
-    public static final HashMap<LegacyApplication, Applet> appToApplet
+    protected static final HashMap<LegacyApplication, Applet> appToApplet
                          = new HashMap<LegacyApplication, Applet>();
 
     protected JmeCanvasContext context;


### PR DESCRIPTION
Resolved by changing the public mutable access specifier to protected to prevent unauthorized or unintended changes and reducing a risk of external modification.

Link to issue
[Issue 3](https://github.com/vaibhav962/jmonkeyengineFall2024/issues/3)

