### PR TITLE
Refactored "public static WHEEL_AMP" field to final - Issue#10

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/input/awt/AwtMouseInput.java
+++ b/jme3-desktop/src/main/java/com/jme3/input/awt/AwtMouseInput.java
@@ -54,7 +54,7 @@ import javax.swing.SwingUtilities;
  */
 public class AwtMouseInput implements MouseInput, MouseListener, MouseWheelListener, MouseMotionListener {
 
-    public static int WHEEL_AMP = 40;   // arbitrary...  Java's mouse wheel seems to report something a lot lower than lwjgl's
+    public static final int WHEEL_AMP = 40;   // arbitrary...  Java's mouse wheel seems to report something a lot lower than lwjgl's
 
     private static final Logger logger = Logger.getLogger(AwtMouseInput.class.getName());
 


### PR DESCRIPTION
The WHEEL_SCALE field was originally private static final, limiting its accessibility and flexibility. This posed a technical debt as the scroll scaling factor couldn't be adjusted or accessed externally if needed.

Link to the Issue
[Issue10](https://github.com/vaibhav962/jmonkeyengineFall2024/issues/10)