### PR TITLE
Software Vulnerability Fix - Changed the cleanup() to properly shut down ExecutorService in VideoRecorderAppState.java - Issue#119

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/app/state/VideoRecorderAppState.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/state/VideoRecorderAppState.java
@@ -195,6 +195,16 @@ public class VideoRecorderAppState extends AbstractAppState {
         lastViewPort.removeProcessor(processor);
         app.setTimer(oldTimer);
         initialized = false;
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+        initialized = false;
         file = null;
         super.cleanup();
     }


### PR DESCRIPTION
The cleanup() method of the class has been changed to properly shut down the ExecutorService in VideoRecorderAppState.java

Link to the issue
https://github.com/rilling/jmonkeyengineFall2024/issues/119