### PR TITLE
Preserve thread interruption status by setting the interrupted flag in catch block for InterruptedException

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/app/state/VideoRecorderAppState.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/state/VideoRecorderAppState.java
@@ -257,9 +257,11 @@ public class VideoRecorderAppState extends AbstractAppState {
                         return null;
                     }
                 });
-            } catch (InterruptedException ex) {
+            }catch (InterruptedException ex) {
                 Logger.getLogger(VideoRecorderAppState.class.getName()).log(Level.SEVERE, null, ex);
+                Thread.currentThread().interrupt(); // Preserve the interrupted status
             }
+
         }
 
         @Override


### PR DESCRIPTION
Updated exception handling for InterruptedException to preserve the thread's interrupt status. This ensures proper thread behavior by setting the interrupted flag when the exception is caught, preventing potential issues with thread coordination.
link to the issue
https://github.com/rilling/jmonkeyengineFall2024/issues/169